### PR TITLE
Remove Kookielang(python) from the list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,16 +134,9 @@
     <br/><br/>
     <img src="https://img.shields.io/github/stars/kookielang/Kookie?style=flat-square">
     <img src="https://img.shields.io/github/license/kookielang/Kookie?style=flat-square">
-    <br/><br/>
-  <a href="https://github.com/kookielang/Kookie"><sup><strong>Python</strong></sup></a>
-    <br/>
     <img src="https://img.shields.io/github/last-commit/kookielang/Kookie?style=flat-square">
     <img src="https://img.shields.io/github/languages/top/kookielang/Kookie?style=flat-square">
-    <br/>
-  <a href="https://github.com/kookielang/KookieNet"><sup><strong>C#</strong></sup></a>
-    <br/>
-    <img src="https://img.shields.io/github/last-commit/kookielang/KookieNet?style=flat-square">
-    <img src="https://img.shields.io/github/languages/top/kookielang/KookieNet?style=flat-square">
+    <br/><br/>
   </p>
   
 <h2></h2>


### PR DESCRIPTION
The python version of kookie has been deprecated and will be removed in the future.
### changes
- removed kookielang(python) from the readme.